### PR TITLE
feat(actions): add /sim/action endpoint, CLI flags

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/qri-io/apiutil"
+	"github.com/qri-io/dataset"
+	"github.com/qri-io/qri/lib"
+	reporef "github.com/qri-io/qri/repo/ref"
+)
+
+// SimActionHandler triggers actions on this server that simulate real-world
+// behaviour
+func SimActionHandler(inst *lib.Instance) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		key := strings.ToLower(r.FormValue("action"))
+		act, ok := simActions[key]
+		if !ok {
+			apiutil.WriteErrResponse(w, http.StatusBadRequest, fmt.Errorf("action not found: '%s'", key))
+			return
+		}
+
+		if err := act(r.Context(), inst); err != nil {
+			log.Errorf("running action %s: %s", key, err)
+			apiutil.WriteErrResponse(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		apiutil.WriteResponse(w, "ok")
+	}
+}
+
+// simActions is a mapping of simulation actions keyed by string
+var simActions = map[string]simActionFunc{
+	"createsynthsdataset": createSynthsDataset,
+	"appendsynthsdataset": appendSynthsDataset,
+}
+
+type simActionFunc func(ctx context.Context, inst *lib.Instance) error
+
+func createSynthsDataset(ctx context.Context, inst *lib.Instance) error {
+	dsm := lib.NewDatasetRequestsInstance(inst)
+	res := reporef.DatasetRef{}
+	err := dsm.Save(&lib.SaveParams{
+		Publish: true,
+		Ref:     "me/synths",
+		Dataset: &dataset.Dataset{
+			Meta: &dataset.Meta{
+				Title:       "synthesizers",
+				Description: "A list of great types of synthesizers",
+			},
+			BodyPath: "body.csv",
+			BodyBytes: []byte(`company,name,year_of_release,initial_cost,initial_cost_adjusted
+moog,little phatty,,,,
+moog,sub 37,,,,
+moog,subsequent 37,,,,
+`),
+		},
+	}, &res)
+
+	if err == nil {
+		log.Infof("createSynthsDataset dataset saved: %s", res)
+	}
+
+	return err
+}
+
+func appendSynthsDataset(ctx context.Context, inst *lib.Instance) error {
+	dsm := lib.NewDatasetRequestsInstance(inst)
+	res := reporef.DatasetRef{}
+	err := dsm.Save(&lib.SaveParams{
+		Publish: true,
+		Ref:     "me/synths",
+		Dataset: &dataset.Dataset{
+			BodyPath: "body.csv",
+			BodyBytes: []byte(`company,name,year_of_release,initial_cost,initial_cost_adjusted
+moog,little phatty,,,,
+moog,sub 37,,,,
+moog,subsequent 37,,,,
+novation,bass station,,,,
+`),
+		},
+	}, &res)
+
+	if err == nil {
+		log.Infof("appendSynthsDataset saved: %s", res)
+	}
+
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ replace (
 
 require (
 	github.com/ipfs/go-log v1.0.1
+	github.com/qri-io/apiutil v0.1.0
 	github.com/qri-io/dataset v0.1.5-0.20191126212116-72b5aa69790b
 	github.com/qri-io/qri v0.9.5-0.20200203222406-e3086cfd1944
 )

--- a/go.sum
+++ b/go.sum
@@ -16,7 +16,9 @@ github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cB
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
@@ -70,8 +72,6 @@ github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzA
 github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger v2.0.0-rc.2+incompatible h1:7KPp6xv5+wymkVUbkAnZZXvmDrJlf09m/7u1HG5lAYA=
-github.com/dgraph-io/badger v2.0.0-rc.2+incompatible/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -891,6 +891,7 @@ google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/temp.go
+++ b/temp.go
@@ -6,14 +6,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/qri-io/dataset"
 	"github.com/qri-io/qri/config"
 	"github.com/qri-io/qri/lib"
 	"github.com/qri-io/qri/registry"
 	"github.com/qri-io/qri/registry/regserver"
 	"github.com/qri-io/qri/remote"
 	"github.com/qri-io/qri/repo/gen"
-	reporef "github.com/qri-io/qri/repo/ref"
 )
 
 // NewTempRepoRegistry creates a temporary repo & builds a registry atop it.
@@ -24,6 +22,8 @@ func NewTempRepoRegistry(ctx context.Context) (*lib.Instance, registry.Registry,
 	if err != nil {
 		return nil, registry.Registry{}, nil, err
 	}
+	log.Infof("temp registry location: %s", RootPath)
+
 	// Create directory for new IPFS repo.
 	IPFSPath := filepath.Join(RootPath, "ipfs")
 	err = os.MkdirAll(IPFSPath, os.ModePerm)
@@ -105,25 +105,4 @@ func NewTempRepoRegistry(ctx context.Context) (*lib.Instance, registry.Registry,
 	}
 
 	return inst, reg, cleanup, nil
-}
-
-func addBasicDataset(inst *lib.Instance) {
-	dsm := lib.NewDatasetRequestsInstance(inst)
-	res := reporef.DatasetRef{}
-	err := dsm.Save(&lib.SaveParams{
-		Publish: true,
-		Ref:     "me/dataset",
-		Dataset: &dataset.Dataset{
-			Meta: &dataset.Meta{
-				Title: "I'm a dataset",
-			},
-			BodyPath: "body.csv",
-			BodyBytes: []byte(`a,b,c,true,2
-d,e,f,false,3`),
-		},
-	}, &res)
-
-	if err != nil {
-		log.Fatalf("saving dataset verion: %s", err)
-	}
 }


### PR DESCRIPTION
some nicer dev ergonomics. first, two new flags:

```
--port       - set the port
--no-cleanup - don't delete the directory on close
```

skipping cleanup can help for after-the-fact inspection of the resulting repo.

This also adds a new endpoint for triggering hard-coded actions on the registry. after spinning up a registry you can now trigger an additional commit on the baseline dataset:
```
curl "http://localhost:2500/sim/action?action=appendsynthsdataset"
```