### PR TITLE
feat(logLevel): add `--log-level` cmd line flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	github.com/ipfs/go-log v1.0.4
 	github.com/qri-io/apiutil v0.2.0
 	github.com/qri-io/dataset v0.2.0
-	github.com/qri-io/qri v0.9.12
+	github.com/qri-io/qri v0.9.13-0.20200911220929-2bb6de0040c1
 )

--- a/go.sum
+++ b/go.sum
@@ -1089,6 +1089,10 @@ github.com/qri-io/qri v0.9.12-0.20200910190341-0cac9f772228 h1:X+Dpu+Hr53sbusM6b
 github.com/qri-io/qri v0.9.12-0.20200910190341-0cac9f772228/go.mod h1:9/+IlmUk9hNqmzqC6yAhjNWRquel/Sfc/xarnIBqKdo=
 github.com/qri-io/qri v0.9.12 h1:maKwnZkkXGk4BYUUUujJi1tqaDzEYvUcQWupf0FPiE0=
 github.com/qri-io/qri v0.9.12/go.mod h1:9/+IlmUk9hNqmzqC6yAhjNWRquel/Sfc/xarnIBqKdo=
+github.com/qri-io/qri v0.9.13-0.20200911203835-0d4b9ba63341 h1:xkEPozxTGdgbWl9+JJEUQLjtN+dy9+JtkcIWvkVH/CM=
+github.com/qri-io/qri v0.9.13-0.20200911203835-0d4b9ba63341/go.mod h1:9/+IlmUk9hNqmzqC6yAhjNWRquel/Sfc/xarnIBqKdo=
+github.com/qri-io/qri v0.9.13-0.20200911220929-2bb6de0040c1 h1:r/wVqmjhJMkcsNQLpCU8F0r5YfPvqSPh1CAVh2o8zsI=
+github.com/qri-io/qri v0.9.13-0.20200911220929-2bb6de0040c1/go.mod h1:9/+IlmUk9hNqmzqC6yAhjNWRquel/Sfc/xarnIBqKdo=
 github.com/qri-io/starlib v0.4.2 h1:ZGzmzT9fOqdluezcwhAZAbTn/v6kMg1tC6ALVjQPhpQ=
 github.com/qri-io/starlib v0.4.2/go.mod h1:2xlZ9r2UV4LF4G9mpYPBWo7CtXtdW0h1RoGIkZ8elOE=
 github.com/qri-io/varName v0.1.0 h1:dFP5qZHrxnn5fNoMbjfpMCRBYDrOsoyls7R07r+emk0=

--- a/server.go
+++ b/server.go
@@ -18,6 +18,7 @@ var (
 	log      = logger.Logger("regserver")
 	adminKey string
 
+	logLevel  string
 	port      string
 	noCleanup bool
 )
@@ -25,6 +26,7 @@ var (
 func init() {
 	flag.StringVar(&port, "port", "2500", "port to listen on. default: `2500`")
 	flag.BoolVar(&noCleanup, "no-cleanup", false, "don't remove directory on close")
+	flag.StringVar(&logLevel, "log-level", "info", "set the remote's log level ['info', 'debug', 'warn', 'error']")
 }
 
 func main() {
@@ -34,7 +36,7 @@ func main() {
 	ctx := context.Background()
 
 	log.Info("creating temporary registry")
-	inst, reg, cleanup, err := NewTempRepoRegistry(ctx)
+	inst, reg, cleanup, err := NewTempRepoRegistry(ctx, logLevel)
 	if err != nil {
 		log.Fatalf("creating temp registry: %s", err)
 	}

--- a/temp.go
+++ b/temp.go
@@ -18,7 +18,7 @@ import (
 // NewTempRepoRegistry creates a temporary repo & builds a registry atop it.
 // callers should always call the returned cleanup function when finished to
 // remove temp files
-func NewTempRepoRegistry(ctx context.Context) (*lib.Instance, registry.Registry, func(), error) {
+func NewTempRepoRegistry(ctx context.Context, logLevel string) (*lib.Instance, registry.Registry, func(), error) {
 	RootPath, err := ioutil.TempDir("", "temp_repo_registry")
 	if err != nil {
 		return nil, registry.Registry{}, nil, err
@@ -67,6 +67,15 @@ func NewTempRepoRegistry(ctx context.Context) (*lib.Instance, registry.Registry,
 		AcceptTimeoutMs:  -1,
 		RequireAllBlocks: false,
 		AllowRemoves:     true,
+	}
+
+	cfg.Logging.Levels = map[string]string{
+		"qriapi":  logLevel,
+		"qrip2p":  logLevel,
+		"remote":  logLevel,
+		"logbook": logLevel,
+		"logsync": logLevel,
+		"repo":    logLevel,
 	}
 
 	err = lib.Setup(lib.SetupParams{


### PR DESCRIPTION
This flag will set the log level of the underlying qri remote. Without adding log levels, I would never have been able to debug our `RemoveDataset` on a remote problem!